### PR TITLE
Fixes for Pylint and test refactoring

### DIFF
--- a/comment_spell_check/lib/bibtex_loader.py
+++ b/comment_spell_check/lib/bibtex_loader.py
@@ -1,3 +1,5 @@
+""" Load Bibtex files into a spell checking dictionary. """
+
 import bibtexparser
 
 

--- a/tests/test_comment_spell_check.py
+++ b/tests/test_comment_spell_check.py
@@ -33,14 +33,16 @@ class TestCommentSpellCheck(unittest.TestCase):
         """Basic test"""
         runresult = subprocess.run(
             [
-                "comment_spell_check",
-                "--miss",
+                "python",
+                "comment_spell_check.py",
+                "--verbose",
                 "--dict",
-                "tests/dict.txt",
+                "../tests/dict.txt",
                 "--prefix",
                 "myprefix",
-                "tests/example.h",
+                "../tests/example.h",
             ],
+            cwd="comment_spell_check",
             stdout=subprocess.PIPE,
         )
         self.assertEqual(runresult.returncode, 0, runresult.stdout)
@@ -49,8 +51,9 @@ class TestCommentSpellCheck(unittest.TestCase):
         """Code base test"""
         runresult = subprocess.run(
             [
-                "comment_spell_check",
-                "--miss",
+                "python",
+                "comment_spell_check.py",
+                "--verbose",
                 "--prefix",
                 "myprefix",
                 "--suffix",
@@ -59,6 +62,7 @@ class TestCommentSpellCheck(unittest.TestCase):
                 ".md",
                 ".",
             ],
+            cwd="comment_spell_check",
             stdout=subprocess.PIPE,
         )
         self.assertEqual(runresult.returncode, 0, runresult.stdout)
@@ -67,9 +71,11 @@ class TestCommentSpellCheck(unittest.TestCase):
         """Version test"""
         runresult = subprocess.run(
             [
-                "comment_spell_check",
+                "python",
+                "comment_spell_check.py",
                 "--version",
             ],
+            cwd="comment_spell_check",
             stdout=subprocess.PIPE,
         )
         self.assertEqual(runresult.returncode, 0)
@@ -83,11 +89,14 @@ class TestCommentSpellCheck(unittest.TestCase):
         """Bibtext test"""
         runresult = subprocess.run(
             [
-                "comment_spell_check",
+                "python",
+                "comment_spell_check.py",
+                "--verbose",
                 "--bibtex",
-                "tests/itk.bib",
-                "tests/bibtest.py",
+                "../tests/itk.bib",
+                "../tests/bibtest.py",
             ],
+            cwd="comment_spell_check",
             stdout=subprocess.PIPE,
         )
         self.assertEqual(runresult.returncode, 0, runresult.stdout)


### PR DESCRIPTION
The tests were changed to launch with the python executable and run in the comment_spell_check subdir.